### PR TITLE
chore(dependencies): upgrade `grunt-contrib-connect` to ~0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bower": "~1.2.7",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-parallel": "~0.3.1",
-    "grunt-contrib-connect": "~0.6.0",
+    "grunt-contrib-connect": "~0.7.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-gh-pages": "~0.9.0",


### PR DESCRIPTION
Busywork~
