### PR TITLE
chore(dependencies): upgrade to angular 1.2.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,9 +29,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.7",
-    "angular-animate": "~1.2.7",
-    "angular-mocks": "~1.2.7",
-    "angular-route": "~1.2.7"
+    "angular": "1.2.13",
+    "angular-animate": "1.2.13",
+    "angular-mocks": "1.2.13",
+    "angular-route": "1.2.13"
   }
 }


### PR DESCRIPTION
For what reason? Mainly to see if ngAnimate@1.2.13 broke any animations in the
demo page. But it seems like we're good.
